### PR TITLE
Fix for Potential Memory Leak

### DIFF
--- a/api-local/src/main/java/io/github/projectunified/unihologram/api/local/LocalHologramProvider.java
+++ b/api-local/src/main/java/io/github/projectunified/unihologram/api/local/LocalHologramProvider.java
@@ -12,7 +12,32 @@ import java.util.*;
  * @param <T> the type of the location
  */
 public abstract class LocalHologramProvider<T> implements HologramProvider<T> {
-    private final Map<String, Hologram<T>> createdHolograms = new HashMap<>();
+    private static final int CLEANUP_SIZE = 256;
+
+    private final Map<String, Hologram<T>> createdHolograms = new LinkedHashMap<String, Hologram<T>>(16, 0.75F, true) {
+        @Override
+        protected boolean removeEldestEntry(@NotNull Map.Entry<String, Hologram<T>> eldest) {
+            if (size() > CLEANUP_SIZE) {
+                final Hologram<T> hologram = eldest.getValue();
+                if (hologram == null) {
+                    return true;
+                } else {
+                    if (hologram.isInitialized()) {
+                        changeToNewestAccessOrder(eldest);
+                    } else {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // Change the access-order from the oldest to the newest.
+        private void changeToNewestAccessOrder(@NotNull Map.Entry<String, Hologram<T>> eldest) {
+            get(eldest);
+        }
+    };
 
     /**
      * Make a new hologram


### PR DESCRIPTION
In my specific plugin implementation, holograms with different names are frequently created, often influenced by player actions. This could theoretically lead to memory overflow.

[Original Code](https://github.com/ProjectUnified/UniHologram/blob/0a96e249d38306c3349cd01512301ca2b189117e/api-local/src/main/java/io/github/projectunified/unihologram/api/local/LocalHologramProvider.java#L15C5-L15C79):
```java
    private final Map<String, Hologram<T>> createdHolograms = new HashMap<>();
```

The issue with this implementation is that the map is never cleared, nor does it have any size limitations. As new holograms are created, the map keeps growing indefinitely, which is not ideal.

I suggest avoiding a scheduler-based cleanup approach (as it adds unnecessary overhead every tick) or directly removing elements when Hologram.clear() is called to retain references to hologram objects in map.

My Implementation:
```java
    private static final int CLEANUP_SIZE = 256;

    private final Map<String, Hologram<T>> createdHolograms = new LinkedHashMap<String, Hologram<T>>(16, 0.75F, true) {
        @Override
        protected boolean removeEldestEntry(@NotNull Map.Entry<String, Hologram<T>> eldest) {
            if (size() > CLEANUP_SIZE) {
                final Hologram<T> hologram = eldest.getValue();
                if (hologram == null) {
                    return true;
                } else {
                    if (hologram.isInitialized()) {
                        changeToNewestAccessOrder(eldest);
                    } else {
                        return true;
                    }
                }
            }

            return false;
        }

        // Change the access-order from the oldest to the newest.
        private void changeToNewestAccessOrder(@NotNull Map.Entry<String, Hologram<T>> eldest) {
            get(eldest);
        }
    };
```
This implementation replaces the HashMap with a LinkedHashMap, which preserves the insertion order of elements.

If the number of elements in the map exceeds this limit (A constant CLEANUP_SIZE is set to 256), the oldest elements are checked for removal based on these conditions:
1. The element is null.
2. The hologram is not initialized.

If an element cannot be removed (e.g., it is initialized), it becomes the most recently accessed element and is moved to the end of the list. Upon the next attempt to remove the oldest element, the next item in the list will be considered.